### PR TITLE
[doc] : Adding angular-jk-carousel bower installation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Demo : https://embed.plnkr.co/ovBExhpO40yzWPJ47QFE/
 ### npm
 `npm install angular-jk-carousel`
 
+### bower
+`bower install angular-jk-carousel`
+
 ## Usage :
 
  - Add `jk-carousel.js` to your index file:


### PR DESCRIPTION
Since bower support is done, I've just add the bower installation documentation to the README.MD file.

It references issue #10 which can be closed in my opinion.